### PR TITLE
feat: implement agent registry schema and audita agent

### DIFF
--- a/agents/audita/agent.py
+++ b/agents/audita/agent.py
@@ -1,23 +1,27 @@
-"""Echo agent: simple message relay."""
+"""Audita agent: compliance and legal checks."""
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from agents.base import Agent
 
 
-class EchoAgent(Agent):
+class AuditaAgent(Agent):
+    """Performs simple text compliance scans."""
+
     def __init__(self) -> None:
-        super().__init__("echo", description="Comms relay agent")
+        super().__init__("audita", description="Compliance and audit agent")
 
     def run(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         command = payload.get("command")
         args = payload.get("args", {})
         try:
-            if command != "echo":
+            if command != "scan_text":
                 raise ValueError(f"unknown command '{command}'")
-            message = args.get("message", "")
-            output = {"echo": message}
+            text = args.get("text", "")
+            prohibited: List[str] = args.get("prohibited", [])
+            violations = [term for term in prohibited if term in text]
+            output = {"violations": violations, "compliant": not violations}
             if payload.get("log"):
                 self.log_result(output)
             return {"success": True, "output": output, "error": None}

--- a/agents/base.py
+++ b/agents/base.py
@@ -1,40 +1,40 @@
 # core/base.py
 
 import abc
+import json
+import os
+from datetime import datetime
 from typing import Any, Dict
 
-class BaseAgent(abc.ABC):
-    """
-    Abstract base class for all NovaOS agents.
-    Ensures all agents follow a common interface.
-    """
 
-    def __init__(self, name: str):
+class BaseAgent(abc.ABC):
+    """Common interface for all NovaOS agents."""
+
+    def __init__(self, name: str, version: str = "1.0", description: str = "") -> None:
         self.name = name
+        self.version = version
+        self.description = description
 
     @abc.abstractmethod
-    def run(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+    def run(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         """
-        Execute agent logic. Must be implemented by subclasses.
-        Args:
-            input_data: A dictionary containing task-specific input.
-        Returns:
-            A dictionary containing the agent's structured output.
-        """
-        pass
+        Execute agent logic and return a standardized response.
 
-    def log_result(self, result: Dict[str, Any]):
+        The response dict **must** contain the keys:
+            success (bool)
+            output (dict | None)
+            error (str | None)
         """
-        Save the result to file and/or console.
-        Override this for custom logging logic per agent.
-        """
-        import json, os
-        from datetime import datetime
 
+    def log_result(self, result: Dict[str, Any]) -> None:
+        """Persist result JSON for this agent."""
         log_dir = f"logs/{self.name}"
         os.makedirs(log_dir, exist_ok=True)
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-        with open(f"{log_dir}/{timestamp}.json", "w") as f:
-            json.dump(result, f, indent=2)
-
+        with open(f"{log_dir}/{timestamp}.json", "w", encoding="utf-8") as fh:
+            json.dump(result, fh, ensure_ascii=False, indent=2)
         print(f"[{self.name}] Result logged at {log_dir}/{timestamp}.json")
+
+
+# Backwards compatibility
+Agent = BaseAgent

--- a/agents/glitch/agent.py
+++ b/agents/glitch/agent.py
@@ -12,19 +12,29 @@ class GlitchAgent(Agent):
     """Provides simple file forensics such as hashing."""
 
     def __init__(self) -> None:
-        super().__init__("glitch")
+        super().__init__("glitch", description="Forensics and hashing agent")
 
-    def run(self, job: Dict[str, Any]) -> Dict[str, Any]:
-        path_str = job.get("path")
-        if not path_str:
-            raise ValueError("missing 'path'")
-        path = Path(path_str)
-        if not path.is_file():
-            raise FileNotFoundError(f"file not found: {path}")
-        data = path.read_bytes()
-        sha256 = hashlib.sha256(data).hexdigest()
-        return {
-            "path": str(path.resolve()),
-            "size": path.stat().st_size,
-            "sha256": sha256,
-        }
+    def run(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        command = payload.get("command")
+        args = payload.get("args", {})
+        try:
+            if command != "hash_file":
+                raise ValueError(f"unknown command '{command}'")
+            path_str = args.get("path")
+            if not path_str:
+                raise ValueError("missing 'path'")
+            path = Path(path_str)
+            if not path.is_file():
+                raise FileNotFoundError(f"file not found: {path}")
+            data = path.read_bytes()
+            sha256 = hashlib.sha256(data).hexdigest()
+            output = {
+                "path": str(path.resolve()),
+                "size": path.stat().st_size,
+                "sha256": sha256,
+            }
+            if payload.get("log"):
+                self.log_result(output)
+            return {"success": True, "output": output, "error": None}
+        except Exception as exc:  # noqa: BLE001
+            return {"success": False, "output": None, "error": str(exc)}

--- a/agents/glitch/tests/test_agent.py
+++ b/agents/glitch/tests/test_agent.py
@@ -19,7 +19,9 @@ def test_glitch_reports_file_metadata(tmp_path, monkeypatch):
     registry.register("glitch", GlitchAgent())
     nova = NovaAgent(registry)
 
-    result = nova.run({"agent": "glitch", "payload": {"path": str(sample)}})
+    result = nova.run(
+        {"agent": "glitch", "command": "hash_file", "args": {"path": str(sample)}}
+    )
     assert result["success"] is True
     output = result["output"]
     assert output["sha256"] == expected

--- a/agents/nova/agent.py
+++ b/agents/nova/agent.py
@@ -9,16 +9,18 @@ from core.registry import AgentRegistry, AgentResponse
 
 class NovaAgent(Agent):
     def __init__(self, registry: AgentRegistry) -> None:
-        super().__init__("nova")
+        super().__init__("nova", description="Platform orchestrator")
         self._registry = registry
 
-    def run(self, job: Dict[str, Any]) -> Dict[str, Any]:
-        target = job.get("agent")
+    def run(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        target = payload.get("agent")
         if not target:
-            raise ValueError("missing target agent")
-        payload = job.get("payload", {})
-        token = job.get("token")
-        resp: AgentResponse = self._registry.call(target, payload, token)
+            return {"success": False, "output": None, "error": "missing target agent"}
+        command = payload.get("command")
+        args = payload.get("args", {})
+        token = payload.get("token")
+        job = {"command": command, "args": args, "log": payload.get("log")}
+        resp: AgentResponse = self._registry.call(target, job, token)
         return {
             "invoked": target,
             "success": resp.success,


### PR DESCRIPTION
## Summary
- standardize BaseAgent interface and logging
- add Audita compliance agent and command-based Echo/Glitch behavior
- update AgentRegistry with secure response schema and per-agent logs

## Testing
- `pytest agents/glitch/tests core/tests`
- `pytest` *(fails: ModuleNotFoundError: No module named 'rsa')*
- `pnpm test:all` *(fails: vitest not found; missing node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a379222a748324ad3d77aa549019c0