### PR TITLE
feat: add agent control API and console UI

### DIFF
--- a/apps/nova-console/app/page.tsx
+++ b/apps/nova-console/app/page.tsx
@@ -1,103 +1,59 @@
-import Image from "next/image";
+'use client'
+import { useState } from 'react'
+
+const AGENTS = ['glitch', 'echo']
 
 export default function Home() {
-  return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const [agent, setAgent] = useState('glitch')
+  const [command, setCommand] = useState('')
+  const [args, setArgs] = useState('{}')
+  const [log, setLog] = useState(false)
+  const [result, setResult] = useState<Record<string, unknown> | null>(null)
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+  async function runAgent(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const res = await fetch(`http://localhost:8750/agents/${agent}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        command,
+        args: JSON.parse(args || '{}'),
+        log,
+      }),
+    })
+    setResult(await res.json())
+  }
+
+  return (
+    <div className="p-8">
+      <form onSubmit={runAgent} className="flex flex-col gap-2 max-w-md">
+        <label className="flex flex-col">
+          Agent
+          <select value={agent} onChange={e => setAgent(e.target.value)} className="border p-1">
+            {AGENTS.map(a => (
+              <option key={a} value={a}>{a}</option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col">
+          Command
+          <input value={command} onChange={e => setCommand(e.target.value)} className="border p-1" />
+        </label>
+        <label className="flex flex-col">
+          Args JSON
+          <input value={args} onChange={e => setArgs(e.target.value)} className="border p-1 font-mono" />
+        </label>
+        <label className="flex items-center gap-2">
+          <input type="checkbox" checked={log} onChange={e => setLog(e.target.checked)} />
+          Log
+        </label>
+        <button type="submit" className="border px-2 py-1">Run</button>
+      </form>
+      {result && (
+        <pre className="mt-4 bg-gray-100 p-2 text-sm overflow-x-auto">
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      )}
     </div>
-  );
+  )
 }

--- a/services/core-api/app/main.py
+++ b/services/core-api/app/main.py
@@ -17,6 +17,7 @@ from app.routes import (
     dmca,
     analytics,
     internal,
+    agents,
 )
 
 app = FastAPI(title="Nova Core API")
@@ -43,6 +44,7 @@ app.include_router(consent.router)
 app.include_router(internal.router)
 app.include_router(dmca.router)
 app.include_router(analytics.router)
+app.include_router(agents.router)
 
 
 @app.get("/healthz")

--- a/services/core-api/app/routes/__init__.py
+++ b/services/core-api/app/routes/__init__.py
@@ -1,4 +1,4 @@
-from . import auth, palettes, payments, rooms, messages, consent, dmca, analytics
+from . import auth, palettes, payments, rooms, messages, consent, dmca, analytics, agents
 
 __all__ = [
     "auth",
@@ -9,4 +9,5 @@ __all__ = [
     "consent",
     "dmca",
     "analytics",
+    "agents",
 ]

--- a/services/core-api/app/routes/agents.py
+++ b/services/core-api/app/routes/agents.py
@@ -1,0 +1,45 @@
+import os
+import sys
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+sys.path.append(str(Path(__file__).resolve().parents[4]))
+
+from agents.echo.agent import EchoAgent  # noqa: E402
+from agents.glitch.agent import GlitchAgent  # noqa: E402
+from agents.nova.agent import NovaAgent  # noqa: E402
+from core.registry import AgentRegistry  # noqa: E402
+
+router = APIRouter(prefix="/agents", tags=["agents"])
+
+_registry = AgentRegistry(token=os.getenv("NOVA_AGENT_TOKEN"))
+_registry.register("glitch", GlitchAgent())
+_registry.register("echo", EchoAgent())
+_nova = NovaAgent(_registry)
+
+
+class Job(BaseModel):
+    command: str
+    args: dict = {}
+    log: bool = False
+    token: str | None = None
+
+
+@router.post("/{agent}")
+def run_agent(agent: str, job: Job):
+    payload = {
+        "agent": agent,
+        "command": job.command,
+        "args": job.args,
+        "log": job.log,
+    }
+    if job.token:
+        payload["token"] = job.token
+    try:
+        return _nova.run(payload)
+    except PermissionError as exc:
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc


### PR DESCRIPTION
## Summary
- add FastAPI route to execute registered agents
- expose agents API through Nova Core API
- wire console UI to run agents from dashboard

## Testing
- `pnpm lint:all`
- `pnpm test:all`
- `python -m pytest agents/glitch/tests/test_agent.py core/tests/test_registry.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4f81b34908324b99cc8a332e84171