### PR TITLE
feat: add agent run and forensics scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,18 @@ Env vars (.env.echo):
 
 ## Sovereign Standard
 Local-first, consent-bound, RBAC enforced, Founder controls everything.
+
+## CLI
+
+Run NovaOS agents directly from the terminal:
+
+```bash
+./scripts/run-agent.sh echo send_message '{"message":"hi"}'
+```
+
+Glitch forensics shortcuts:
+
+```bash
+./scripts/forensics.sh hash path/to/file
+./scripts/forensics.sh scan
+```

--- a/scripts/forensics.sh
+++ b/scripts/forensics.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "usage: $0 <hash|entropy|scan|probe> [args]" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_AGENT="$SCRIPT_DIR/run-agent.sh"
+
+CMD="$1"
+shift || true
+case "$CMD" in
+  hash)
+    [ $# -eq 1 ] || { echo "usage: $0 hash <path>" >&2; exit 1; }
+    PAYLOAD="{\"path\":\"$1\"}"
+    "$RUN_AGENT" glitch hash_file "$PAYLOAD"
+    ;;
+  entropy)
+    [ $# -eq 1 ] || { echo "usage: $0 entropy <path>" >&2; exit 1; }
+    PAYLOAD="{\"path\":\"$1\"}"
+    "$RUN_AGENT" glitch detect_entropy "$PAYLOAD"
+    ;;
+  scan)
+    [ $# -eq 0 ] || { echo "usage: $0 scan" >&2; exit 1; }
+    "$RUN_AGENT" glitch scan_system
+    ;;
+  probe)
+    HOST="${1:-127.0.0.1}"
+    shift || true
+    if [ $# -gt 0 ]; then
+      PORTS=$(printf ',%s' "$@")
+      PORTS="${PORTS:1}"
+    else
+      PORTS="22,80,443"
+    fi
+    PAYLOAD="{\"host\":\"$HOST\",\"ports\":[${PORTS}] }"
+    "$RUN_AGENT" glitch network_probe "$PAYLOAD"
+    ;;
+  *)
+    echo "unknown command: $CMD" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "usage: $0 <agent> <command> [json-args]" >&2
+  exit 1
+fi
+
+AGENT="$1"
+COMMAND="$2"
+if [ $# -ge 3 ]; then
+  ARGS="$3"
+else
+  ARGS='{}'
+fi
+TOKEN="${NOVA_AGENT_TOKEN:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}/.."
+
+python - "$AGENT" "$COMMAND" "$ARGS" "$TOKEN" <<'PYTHON'
+import json, sys
+from core.registry import AgentRegistry
+from agents.echo.agent import EchoAgent
+from agents.glitch.agent import GlitchAgent
+from agents.lyra.agent import LyraAgent
+from agents.velora.agent import VeloraAgent
+from agents.audita.agent import AuditaAgent
+from agents.riven.agent import RivenAgent
+from agents.nova.agent import NovaAgent
+
+agent_name = sys.argv[1]
+command = sys.argv[2]
+args = json.loads(sys.argv[3] or "{}")
+token = sys.argv[4] or None
+
+registry = AgentRegistry(token=token)
+registry.register("echo", EchoAgent())
+registry.register("glitch", GlitchAgent())
+registry.register("lyra", LyraAgent())
+registry.register("velora", VeloraAgent())
+registry.register("audita", AuditaAgent())
+registry.register("riven", RivenAgent())
+nova = NovaAgent(registry)
+
+job = {"agent": agent_name, "command": command, "args": args}
+if token:
+    job["token"] = token
+
+response = nova.run(job)
+print(json.dumps(response, ensure_ascii=False))
+PYTHON


### PR DESCRIPTION
## Summary
- add scripts/run-agent.sh for executing registered agents via Nova orchestrator
- add scripts/forensics.sh to expose glitch agent hashing, entropy, scan, and network probe helpers
- document CLI usage in root README

## Testing
- `scripts/run-agent.sh echo send_message '{"message":"hi"}'`
- `scripts/forensics.sh hash tmpfile.txt`
- `pytest agents/glitch/tests core/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4ff9d119483249ada0ada7b179225