### PR TITLE
phase3: ui + console wiring complete

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,5 @@ JWT_PUBLIC_KEY_PATH=./keys/dev_jwt_public.pem
 PLATFORM_CUT=0.12
 
 # App URLs
-CORE_API_URL=http://localhost:8000
-ECHO_WS_URL=ws://localhost:8010/ws
-NEXT_PUBLIC_ECHO_WS_URL=ws://localhost:8010/ws
+CORE_API_BASE=http://localhost:8760
+ECHO_WS=ws://localhost:8765/ws

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,26 @@
+# STATUS
+**Phase 2: Complete**
+- BaseAgent + Registry: `agents/base.py`, `core/registry.py` (token-gated, JSON logs)
+- Agents: nova, echo, glitch, lyra, velora, audita, riven
+
+## Sample payloads
+- Nova → Echo: `{"agent":"echo","command":"send_message","args":{"message":"hi"}}`
+- Glitch hash: `{"command":"hash_file","args":{"path":"./README.md"}}`
+- Lyra prompt: `{"command":"create_prompt","args":{"type":"writing"}}`
+- Velora report: `{"command":"generate_report","args":{"data":{"a":1,"b":2}}}`
+- Audita GDPR: `{"command":"gdpr_scan","args":{"data":"email test a@b.com"}}`
+- Riven protocol: `{"command":"generate_protocol","args":{"title":"Bugout","steps":["Pack","Drive"]}}`
+
+## Phase 3 usage
+- **UI**: All apps proxy agent calls via `/api/agents/{agent}` (no client token).
+- **CLI**:
+  - `NOVA_AGENT_TOKEN=changeme ./scripts/run-agent.sh echo send_message '{"message":"hi"}'`
+  - `NOVA_AGENT_TOKEN=changeme ./scripts/forensics.sh hash ./README.md`
+  - `NOVA_AGENT_TOKEN=changeme ./scripts/audit.sh generate_audit`
+
+## Verify
+- `pnpm lint:all && pnpm test:all`
+- `pnpm dev:all` boots apps with at least one working route
+- UI Console shows agents + outputs
+- Logs written to `logs/{agent}/*.json`
+

--- a/apps/gypsy-cove/app/api/agents/[agent]/route.ts
+++ b/apps/gypsy-cove/app/api/agents/[agent]/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from 'next/server'
+
+export async function POST(req: NextRequest, { params }: { params: { agent: string } }) {
+  const token = process.env.NOVA_AGENT_TOKEN
+  const base = process.env.CORE_API_BASE || process.env.NEXT_PUBLIC_CORE_API_URL
+  if (!token || !base) {
+    return new Response(JSON.stringify({ success:false, output:null, error:'missing server env' }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+  const body = await req.text()
+  const upstream = await fetch(`${base}/agents/${params.agent}`, {
+    method: 'POST',
+    headers: { 'content-type':'application/json', 'X-NOVA-TOKEN': token },
+    body,
+  })
+  const text = await upstream.text()
+  return new Response(text, { status: upstream.status, headers: { 'content-type': upstream.headers.get('content-type') ?? 'application/json' } })
+}
+

--- a/apps/gypsy-cove/app/dashboard/page.tsx
+++ b/apps/gypsy-cove/app/dashboard/page.tsx
@@ -10,12 +10,9 @@ export default function Dashboard(){
 
   async function run(){
     try{
-      const res = await fetch(`${process.env.NEXT_PUBLIC_CORE_API_URL}/agents/${agent}`,{
+      const res = await fetch(`/api/agents/${agent}`, {
         method:'POST',
-        headers:{
-          'Content-Type':'application/json',
-          'X-NOVA-TOKEN': process.env.NOVA_AGENT_TOKEN as string,
-        },
+        headers:{ 'Content-Type':'application/json' },
         body: payload,
       })
       const json = await res.json()

--- a/apps/gypsy-cove/next.config.ts
+++ b/apps/gypsy-cove/next.config.ts
@@ -31,6 +31,8 @@ const nextConfig: NextConfig = {
   },
   env: {
     CORE_API_BASE: process.env.CORE_API_BASE,
+    NEXT_PUBLIC_CORE_API_URL: process.env.CORE_API_BASE,
+    NEXT_PUBLIC_ECHO_WS_URL: process.env.ECHO_WS,
     ECHO_WS: process.env.ECHO_WS,
     SITE_URL: process.env.SITE_URL,
     GC_DOMAIN: process.env.GC_DOMAIN,

--- a/apps/nova-console/app/api/agents/[agent]/route.ts
+++ b/apps/nova-console/app/api/agents/[agent]/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from 'next/server'
+
+export async function POST(req: NextRequest, { params }: { params: { agent: string } }) {
+  const token = process.env.NOVA_AGENT_TOKEN
+  const base = process.env.CORE_API_BASE || process.env.NEXT_PUBLIC_CORE_API_URL
+  if (!token || !base) {
+    return new Response(JSON.stringify({ success:false, output:null, error:'missing server env' }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+  const body = await req.text()
+  const upstream = await fetch(`${base}/agents/${params.agent}`, {
+    method: 'POST',
+    headers: { 'content-type':'application/json', 'X-NOVA-TOKEN': token },
+    body,
+  })
+  const text = await upstream.text()
+  return new Response(text, { status: upstream.status, headers: { 'content-type': upstream.headers.get('content-type') ?? 'application/json' } })
+}
+

--- a/apps/nova-console/app/page.tsx
+++ b/apps/nova-console/app/page.tsx
@@ -26,12 +26,9 @@ export default function Console(){
 
   async function run(){
     try{
-      const res = await fetch(`${process.env.NEXT_PUBLIC_CORE_API_URL}/agents/${agent}`,{
+      const res = await fetch(`/api/agents/${agent}`, {
         method:'POST',
-        headers:{
-          'Content-Type':'application/json',
-          'X-NOVA-TOKEN': process.env.NOVA_AGENT_TOKEN as string,
-        },
+        headers:{ 'Content-Type':'application/json' },
         body: payload,
       })
       const json = await res.json()

--- a/apps/nova-console/next.config.ts
+++ b/apps/nova-console/next.config.ts
@@ -31,6 +31,8 @@ const nextConfig: NextConfig = {
   },
   env: {
     CORE_API_BASE: process.env.CORE_API_BASE,
+    NEXT_PUBLIC_CORE_API_URL: process.env.CORE_API_BASE,
+    NEXT_PUBLIC_ECHO_WS_URL: process.env.ECHO_WS,
     ECHO_WS: process.env.ECHO_WS,
     SITE_URL: process.env.SITE_URL,
     NOVA_CONSOLE_BASE_URL: process.env.NOVA_CONSOLE_BASE_URL,

--- a/apps/web-shell/app/api/agents/[agent]/route.ts
+++ b/apps/web-shell/app/api/agents/[agent]/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from 'next/server'
+
+export async function POST(req: NextRequest, { params }: { params: { agent: string } }) {
+  const token = process.env.NOVA_AGENT_TOKEN
+  const base = process.env.CORE_API_BASE || process.env.NEXT_PUBLIC_CORE_API_URL
+  if (!token || !base) {
+    return new Response(JSON.stringify({ success:false, output:null, error:'missing server env' }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+  const body = await req.text()
+  const upstream = await fetch(`${base}/agents/${params.agent}`, {
+    method: 'POST',
+    headers: { 'content-type':'application/json', 'X-NOVA-TOKEN': token },
+    body,
+  })
+  const text = await upstream.text()
+  return new Response(text, { status: upstream.status, headers: { 'content-type': upstream.headers.get('content-type') ?? 'application/json' } })
+}
+

--- a/apps/web-shell/app/page.tsx
+++ b/apps/web-shell/app/page.tsx
@@ -10,12 +10,9 @@ export default function Shell(){
 
   async function run(){
     try{
-      const res = await fetch(`${process.env.NEXT_PUBLIC_CORE_API_URL}/agents/${agent}`,{
+      const res = await fetch(`/api/agents/${agent}`, {
         method:'POST',
-        headers:{
-          'Content-Type':'application/json',
-          'X-NOVA-TOKEN': process.env.NOVA_AGENT_TOKEN as string,
-        },
+        headers:{ 'Content-Type':'application/json' },
         body: payload,
       })
       const json = await res.json()

--- a/apps/web-shell/next.config.ts
+++ b/apps/web-shell/next.config.ts
@@ -31,6 +31,8 @@ const nextConfig: NextConfig = {
   },
   env: {
     CORE_API_BASE: process.env.CORE_API_BASE,
+    NEXT_PUBLIC_CORE_API_URL: process.env.CORE_API_BASE,
+    NEXT_PUBLIC_ECHO_WS_URL: process.env.ECHO_WS,
     ECHO_WS: process.env.ECHO_WS,
     SITE_URL: process.env.SITE_URL,
     BRC_DOMAIN: process.env.BRC_DOMAIN,

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "preinstall": "npx -y only-allow pnpm",
     "build:all": "pnpm -r run build",
-    "lint:all": "pnpm dlx eslint .",
-    "test:all": "pnpm -r run test",
+    "lint:all": "pnpm -r lint",
+    "test:all": "pnpm -r test",
     "test": "vitest run",
     "dev": "concurrently -n api,echo,web,gc,nova \"pnpm --filter ./services/core-api dev\" \"pnpm --filter ./services/echo dev\" \"pnpm --filter ./apps/web-shell dev\" \"pnpm --filter ./apps/gypsy-cove dev\" \"pnpm --filter ./apps/nova-console dev\"",
-    "dev:all": "pnpm dev"
+    "dev:all": "pnpm -r dev"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",


### PR DESCRIPTION
## Summary
- add secure server-side agent proxy routes to each Next app
- route client dashboards through `/api/agents/{agent}` and drop client tokens
- align env handling across apps, add root `.env.example`, workspace scripts, and STATUS summary

## Testing
- `pnpm lint:all && pnpm test:all`


------
https://chatgpt.com/codex/tasks/task_e_68a523b5567c8324aa141482ab4f0caf